### PR TITLE
Embed atom types and coordinates in HRM model

### DIFF
--- a/models/hrm/hrm_act_v1.py
+++ b/models/hrm/hrm_act_v1.py
@@ -1,15 +1,13 @@
-from typing import Tuple, List, Dict, Optional
+from typing import Tuple, List, Dict
 from dataclasses import dataclass
 import math
 
 import torch
-import torch.nn.functional as F
 from torch import nn
 from pydantic import BaseModel
 
 from models.common import trunc_normal_init_
 from models.layers import rms_norm, SwiGLU, Attention, RotaryEmbedding, CosSin, CastedEmbedding, CastedLinear
-from models.sparse_embedding import CastedSparseEmbedding
 
 
 @dataclass
@@ -31,8 +29,6 @@ class HierarchicalReasoningModel_ACTV1Carry:
 class HierarchicalReasoningModel_ACTV1Config(BaseModel):
     batch_size: int
     seq_len: int
-    puzzle_emb_ndim: int = 0
-    num_puzzle_identifiers: int
     vocab_size: int
 
     H_cycles: int
@@ -109,23 +105,18 @@ class HierarchicalReasoningModel_ACTV1_Inner(nn.Module):
         self.embed_scale  = math.sqrt(self.config.hidden_size)
         embed_init_std = 1.0 / self.embed_scale
 
-        self.embed_tokens = CastedEmbedding(self.config.vocab_size, self.config.hidden_size, init_std=embed_init_std, cast_to=self.forward_dtype)
-        self.lm_head      = CastedLinear(self.config.hidden_size, self.config.vocab_size, bias=False)
-        self.q_head       = CastedLinear(self.config.hidden_size, 2, bias=True)
-
-        self.puzzle_emb_len = -(self.config.puzzle_emb_ndim // -self.config.hidden_size)  # ceil div
-        if self.config.puzzle_emb_ndim > 0:
-            # Zero init puzzle embeddings
-            self.puzzle_emb = CastedSparseEmbedding(self.config.num_puzzle_identifiers, self.config.puzzle_emb_ndim,
-                                                    batch_size=self.config.batch_size, init_std=0, cast_to=self.forward_dtype)
+        self.atom_type_embed = CastedEmbedding(self.config.vocab_size, self.config.hidden_size, init_std=embed_init_std, cast_to=self.forward_dtype)
+        self.coord_encoder  = CastedLinear(3, self.config.hidden_size, bias=False)
+        self.lm_head        = CastedLinear(self.config.hidden_size, self.config.vocab_size, bias=False)
+        self.q_head         = CastedLinear(self.config.hidden_size, 2, bias=True)
 
         # LM Blocks
         if self.config.pos_encodings == "rope":
             self.rotary_emb = RotaryEmbedding(dim=self.config.hidden_size // self.config.num_heads,
-                                              max_position_embeddings=self.config.seq_len + self.puzzle_emb_len,
+                                              max_position_embeddings=self.config.seq_len,
                                               base=self.config.rope_theta)
         elif self.config.pos_encodings == "learned":
-            self.embed_pos = CastedEmbedding(self.config.seq_len + self.puzzle_emb_len, self.config.hidden_size, init_std=embed_init_std, cast_to=self.forward_dtype)
+            self.embed_pos = CastedEmbedding(self.config.seq_len, self.config.hidden_size, init_std=embed_init_std, cast_to=self.forward_dtype)
         else:
             raise NotImplementedError()
 
@@ -143,32 +134,26 @@ class HierarchicalReasoningModel_ACTV1_Inner(nn.Module):
             self.q_head.weight.zero_()
             self.q_head.bias.fill_(-5)  # type: ignore
 
-    def _input_embeddings(self, input: torch.Tensor, puzzle_identifiers: torch.Tensor):
-        # Token embedding
-        embedding = self.embed_tokens(input.to(torch.int32))
+    def _input_embeddings(self, atom_types: torch.Tensor, positions: torch.Tensor):
+        # Atom type embedding
+        embedding = self.atom_type_embed(atom_types.to(torch.int32))
 
-        # Puzzle embeddings
-        if self.config.puzzle_emb_ndim > 0:
-            puzzle_embedding = self.puzzle_emb(puzzle_identifiers)
-            
-            pad_count = self.puzzle_emb_len * self.config.hidden_size - puzzle_embedding.shape[-1]
-            if pad_count > 0:
-                puzzle_embedding = F.pad(puzzle_embedding, (0, pad_count))
-
-            embedding = torch.cat((puzzle_embedding.view(-1, self.puzzle_emb_len, self.config.hidden_size), embedding), dim=-2)
+        # Coordinate encoding
+        coord_embedding = self.coord_encoder(positions.to(self.forward_dtype))
+        embedding = embedding + coord_embedding
 
         # Position embeddings
         if self.config.pos_encodings == "learned":
             # scale by 1/sqrt(2) to maintain forward variance
-            embedding = 0.707106781 * (embedding + self.embed_pos.embedding_weight.to(self.forward_dtype))
+            embedding = 0.707106781 * (embedding + self.embed_pos.embedding_weight[: embedding.shape[1]].to(self.forward_dtype))
 
         # Scale
         return self.embed_scale * embedding
 
     def empty_carry(self, batch_size: int):
         return HierarchicalReasoningModel_ACTV1InnerCarry(
-            z_H=torch.empty(batch_size, self.config.seq_len + self.puzzle_emb_len, self.config.hidden_size, dtype=self.forward_dtype),
-            z_L=torch.empty(batch_size, self.config.seq_len + self.puzzle_emb_len, self.config.hidden_size, dtype=self.forward_dtype),
+            z_H=torch.empty(batch_size, self.config.seq_len, self.config.hidden_size, dtype=self.forward_dtype),
+            z_L=torch.empty(batch_size, self.config.seq_len, self.config.hidden_size, dtype=self.forward_dtype),
         )
         
     def reset_carry(self, reset_flag: torch.Tensor, carry: HierarchicalReasoningModel_ACTV1InnerCarry):
@@ -183,7 +168,7 @@ class HierarchicalReasoningModel_ACTV1_Inner(nn.Module):
         )
 
         # Input encoding
-        input_embeddings = self._input_embeddings(batch["inputs"], batch["puzzle_identifiers"])
+        input_embeddings = self._input_embeddings(batch["atom_types"], batch["positions"])
 
         # Forward iterations
         with torch.no_grad():
@@ -205,7 +190,7 @@ class HierarchicalReasoningModel_ACTV1_Inner(nn.Module):
 
         # LM Outputs
         new_carry = HierarchicalReasoningModel_ACTV1InnerCarry(z_H=z_H.detach(), z_L=z_L.detach())  # New carry no grad
-        output = self.lm_head(z_H)[:, self.puzzle_emb_len:]
+        output = self.lm_head(z_H)
 
         # Q head
         q_logits = self.q_head(z_H[:, 0]).to(torch.float32)
@@ -221,12 +206,8 @@ class HierarchicalReasoningModel_ACTV1(nn.Module):
         self.config = HierarchicalReasoningModel_ACTV1Config(**config_dict)
         self.inner = HierarchicalReasoningModel_ACTV1_Inner(self.config)
 
-    @property
-    def puzzle_emb(self):
-        return self.inner.puzzle_emb
-
     def initial_carry(self, batch: Dict[str, torch.Tensor]):
-        batch_size = batch["inputs"].shape[0]
+        batch_size = batch["atom_types"].shape[0]
 
         return HierarchicalReasoningModel_ACTV1Carry(
             inner_carry=self.inner.empty_carry(batch_size),  # Empty is expected, it will be reseted in first pass as all sequences are halted.


### PR DESCRIPTION
## Summary
- Embed atom types using a dedicated embedding matrix and encode 3D coordinates with a learned linear layer
- Remove puzzle-specific branches and compute sequence length purely from atom ordering

## Testing
- `python -m py_compile models/hrm/hrm_act_v1.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b6cd21990832abc7e1f37cba20a56