### PR TITLE
Add chemical evaluation script and XYZ/ASE export utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,23 @@ OMP_NUM_THREADS=8 torchrun --nproc-per-node 8 evaluate.py checkpoint=<CHECKPOINT
 
 * Then use the provided `arc_eval.ipynb` notebook to finalize and inspect your results.
 
+### Molecular datasets
+
+Chemistry checkpoints can be evaluated and visualized using `evaluate_chem.py`.
+The script computes energy and force errors and can optionally write predicted
+structures to standard formats for inspection in external tools.
+
+```bash
+# Write predictions to XYZ and ASE trajectory files
+python evaluate_chem.py \
+    checkpoint=<CHECKPOINT_PATH> \
+    xyz_path=predictions.xyz \
+    traj_path=predictions.traj
+```
+
+Both `xyz_path` and `traj_path` are optional.  Install
+[`ase`](https://pypi.org/project/ase/) to enable trajectory writing.
+
 ## Notes
 
  - Small-sample learning typically exhibits accuracy variance of around ±2 points.

--- a/evaluate_chem.py
+++ b/evaluate_chem.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+from typing import List, Optional, Dict
+
+import torch
+import torch.distributed as dist
+import yaml
+import pydantic
+from omegaconf import OmegaConf
+
+from pretrain import PretrainConfig, init_train_state, evaluate, create_dataloader
+from utils.chem_io import save_xyz, save_ase_trajectory
+
+
+class EvalChemConfig(pydantic.BaseModel):
+    checkpoint: str
+    save_outputs: List[str] = ["atom_types", "positions", "energy", "forces"]
+    xyz_path: Optional[str] = None
+    traj_path: Optional[str] = None
+
+
+def _gather_predictions(
+    config: PretrainConfig, step: int, world_size: int
+) -> Dict[str, torch.Tensor]:
+    preds: Dict[str, List[torch.Tensor]] = {}
+    for rank in range(world_size):
+        preds_file = os.path.join(
+            config.checkpoint_path, f"step_{step}_all_preds.{rank}"
+        )
+        if not os.path.exists(preds_file):
+            continue
+        loaded = torch.load(preds_file, map_location="cpu")
+        for k, v in loaded.items():
+            preds.setdefault(k, []).append(v)
+    return {k: torch.cat(v, dim=0) for k, v in preds.items()}
+
+
+def launch() -> None:
+    eval_cfg = EvalChemConfig(  # type: ignore
+        **OmegaConf.to_container(OmegaConf.from_cli())
+    )
+
+    rank = 0
+    world_size = 1
+
+    if "LOCAL_RANK" in os.environ:
+        dist.init_process_group(backend="nccl")
+        rank = dist.get_rank()
+        world_size = dist.get_world_size()
+        torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+
+    # Load training configuration
+    with open(
+        os.path.join(os.path.dirname(eval_cfg.checkpoint), "all_config.yaml"), "r"
+    ) as f:
+        config = PretrainConfig(**yaml.safe_load(f))
+        config.eval_save_outputs = eval_cfg.save_outputs
+        config.checkpoint_path = os.path.dirname(eval_cfg.checkpoint)
+
+    train_loader, train_metadata = create_dataloader(
+        config,
+        "train",
+        test_set_mode=False,
+        epochs_per_iter=1,
+        global_batch_size=config.global_batch_size,
+        rank=rank,
+        world_size=world_size,
+    )
+    eval_loader, eval_metadata = create_dataloader(
+        config,
+        "test",
+        test_set_mode=True,
+        epochs_per_iter=1,
+        global_batch_size=config.global_batch_size,
+        rank=rank,
+        world_size=world_size,
+    )
+
+    train_state = init_train_state(config, train_metadata, world_size=world_size)
+    try:
+        train_state.model.load_state_dict(
+            torch.load(eval_cfg.checkpoint, map_location="cuda"), assign=True
+        )
+    except Exception:
+        train_state.model.load_state_dict(
+            {
+                k.removeprefix("_orig_mod."): v
+                for k, v in torch.load(eval_cfg.checkpoint, map_location="cuda").items()
+            },
+            assign=True,
+        )
+
+    train_state.step = 0
+    ckpt_filename = os.path.basename(eval_cfg.checkpoint)
+    if ckpt_filename.startswith("step_"):
+        train_state.step = int(ckpt_filename.removeprefix("step_"))
+
+    train_state.model.eval()
+    metrics = evaluate(
+        config,
+        train_state,
+        eval_loader,
+        eval_metadata,
+        rank=rank,
+        world_size=world_size,
+    )
+
+    if metrics is not None and rank == 0:
+        print(metrics)
+
+    if rank == 0 and (eval_cfg.xyz_path or eval_cfg.traj_path):
+        preds = _gather_predictions(config, train_state.step, world_size)
+        if "atom_types" in preds and "positions" in preds:
+            if eval_cfg.xyz_path:
+                save_xyz(preds, eval_metadata, eval_cfg.xyz_path)
+            if eval_cfg.traj_path:
+                save_ase_trajectory(preds, eval_metadata, eval_cfg.traj_path)
+
+
+if __name__ == "__main__":
+    launch()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ wandb
 omegaconf
 hydra-core
 huggingface_hub
+ase

--- a/utils/chem_io.py
+++ b/utils/chem_io.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import torch
+
+from dataset.common import ChemDatasetMetadata
+
+
+def save_xyz(
+    preds: Dict[str, torch.Tensor],
+    metadata: ChemDatasetMetadata,
+    filename: str,
+) -> None:
+    """Write predictions to an XYZ file.
+
+    Parameters
+    ----------
+    preds : Dict[str, torch.Tensor]
+        Dictionary containing ``atom_types`` and ``positions`` and optionally
+        ``energy``.
+    metadata : ChemDatasetMetadata
+        Dataset metadata used to determine padding value.
+    filename : str
+        Destination XYZ filename.
+    """
+    from ase.data import chemical_symbols
+
+    atom_types = preds["atom_types"].cpu().numpy()
+    positions = preds["positions"].cpu().numpy()
+    energy = preds.get("energy")
+
+    with open(filename, "w") as fh:
+        for i in range(atom_types.shape[0]):
+            mask = atom_types[i] != metadata.pad_atom_type
+            numbers = atom_types[i][mask].astype(int)
+            coords = positions[i][mask]
+
+            fh.write(f"{numbers.size}\n")
+            if energy is not None:
+                fh.write(f"Energy={float(energy[i]):.6f}\n")
+            else:
+                fh.write("\n")
+
+            for n, (x, y, z) in zip(numbers, coords):
+                symbol = (
+                    chemical_symbols[int(n)]
+                    if int(n) < len(chemical_symbols)
+                    else str(int(n))
+                )
+                fh.write(f"{symbol} {x:.6f} {y:.6f} {z:.6f}\n")
+
+
+def save_ase_trajectory(
+    preds: Dict[str, torch.Tensor],
+    metadata: ChemDatasetMetadata,
+    filename: str,
+) -> None:
+    """Write predictions to an ASE trajectory file.
+
+    Parameters
+    ----------
+    preds : Dict[str, torch.Tensor]
+        Dictionary containing ``atom_types`` and ``positions`` and optionally
+        ``energy`` and ``forces``.
+    metadata : ChemDatasetMetadata
+        Dataset metadata used to determine padding value.
+    filename : str
+        Destination trajectory filename.
+    """
+    try:
+        from ase import Atoms  # type: ignore
+        from ase.io.trajectory import Trajectory  # type: ignore
+    except Exception as exc:  # pragma: no cover - optional dependency
+        raise ImportError(
+            "ASE is required to write trajectory files"
+        ) from exc
+
+    atom_types = preds["atom_types"].cpu().numpy()
+    positions = preds["positions"].cpu().numpy()
+    energy = preds.get("energy")
+    forces = preds.get("forces")
+
+    with Trajectory(filename, "w") as traj:
+        for i in range(atom_types.shape[0]):
+            mask = atom_types[i] != metadata.pad_atom_type
+            numbers = atom_types[i][mask].astype(int)
+            coords = positions[i][mask]
+
+            atoms = Atoms(numbers=numbers, positions=coords)
+            if energy is not None:
+                atoms.info["energy"] = float(energy[i])
+            if forces is not None:
+                atoms.arrays["forces"] = forces[i][mask].cpu().numpy()
+            traj.write(atoms)
+
+
+__all__ = ["save_xyz", "save_ase_trajectory"]


### PR DESCRIPTION
## Summary
- introduce `evaluate_chem.py` for energy/force evaluation on molecular test sets with optional XYZ/ASE output
- add `utils/chem_io.py` helpers to write predictions as XYZ or ASE trajectory files
- document chemistry evaluation workflow in `README.md` and require `ase`

## Testing
- `python -m py_compile evaluate_chem.py utils/chem_io.py`
- `pip install ase` *(fails: Could not find a version that satisfies the requirement ase)*
- `python - <<'PY'
import evaluate_chem
PY` *(fails: ModuleNotFoundError: No module named 'adam_atan2_backend')*

------
https://chatgpt.com/codex/tasks/task_e_689b75478f68832a98e80da1177b5645